### PR TITLE
Update gradle and build plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
         distribution: adopt
-        java-version: 11
+        java-version: 17
     - uses: actions/cache@v1
       with:
         path: ~/.gradle/caches

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlinVersion = '1.4.31'
+    ext.kotlinVersion = '1.9.25'
 
     repositories {
         maven {
@@ -13,11 +13,11 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:8.7.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'net.researchgate:gradle-release:2.8.0'
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:10.0.0"
+        classpath 'net.researchgate:gradle-release:3.0.2'
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:12.1.1"
 
         // NOTE: Do not place application dependencies here; they belong
         // in the individual module build.gradle files
@@ -47,7 +47,7 @@ subprojects {
 
     // Optionally configure plugin
     ktlint {
-        version = "0.40.0"
+        version = "1.3.1"
         enableExperimentalRules = true
         debug = true
         android = true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Mar 15 17:34:55 WET 2021
+#Wed Oct 02 15:31:01 WEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/velocidi-sample/build.gradle
+++ b/velocidi-sample/build.gradle
@@ -21,6 +21,14 @@ android {
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
+
+    compileOptions {
+         sourceCompatibility = JavaVersion.VERSION_11
+         targetCompatibility = JavaVersion.VERSION_11
+     }
+     kotlinOptions {
+         jvmTarget = "11"
+     }
 }
 
 dependencies {

--- a/velocidi-sample/build.gradle
+++ b/velocidi-sample/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 30
+    namespace "com.velocidi.sampleapp"
     defaultConfig {
         applicationId "com.velocidi.sampleapp"
         minSdkVersion 19

--- a/velocidi-sample/build.gradle
+++ b/velocidi-sample/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     namespace "com.velocidi.sampleapp"
     defaultConfig {
         applicationId "com.velocidi.sampleapp"
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
     }

--- a/velocidi-sample/src/main/AndroidManifest.xml
+++ b/velocidi-sample/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         <activity android:name=".JavaActivity"></activity>
         <activity
                 android:name=".MainActivity"
+                android:exported="true"
                 android:label="@string/title_activity_main"
                 android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>

--- a/velocidi-sample/src/main/AndroidManifest.xml
+++ b/velocidi-sample/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-        package="com.velocidi.sampleapp">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/velocidi-sample/src/main/java/com/velocidi/sampleapp/MainActivity.kt
+++ b/velocidi-sample/src/main/java/com/velocidi/sampleapp/MainActivity.kt
@@ -8,7 +8,6 @@ import com.velocidi.Velocidi
 import org.json.JSONObject
 
 class MainActivity : AppCompatActivity() {
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -34,23 +33,25 @@ class MainActivity : AppCompatActivity() {
 
             Velocidi.getInstance().track(
                 UserId("user_email_hash", "email_sha256"),
-                eventJsonString
+                eventJsonString,
             )
 
-            val eventJsonObj = mapOf(
-                "clientId" to "velocidi",
-                "siteId" to "velocidi.com",
-                "type" to "appView",
-                "title" to "Welcome Screen",
-                "customFields" to mapOf(
-                    "debug" to true,
-                    "role" to "superuser"
+            val eventJsonObj =
+                mapOf(
+                    "clientId" to "velocidi",
+                    "siteId" to "velocidi.com",
+                    "type" to "appView",
+                    "title" to "Welcome Screen",
+                    "customFields" to
+                        mapOf(
+                            "debug" to true,
+                            "role" to "superuser",
+                        ),
                 )
-            )
 
             Velocidi.getInstance().track(
                 UserId("user_email_hash", "email_sha256"),
-                JSONObject(eventJsonObj)
+                JSONObject(eventJsonObj),
             )
         }
 
@@ -59,8 +60,8 @@ class MainActivity : AppCompatActivity() {
                 "someProvider",
                 listOf(
                     UserId("user_email_hash", "email_sha256"),
-                    UserId("user_advertising_id", "gaid")
-                )
+                    UserId("user_advertising_id", "gaid"),
+                ),
             )
         }
     }

--- a/velocidi-sample/src/main/java/com/velocidi/sampleapp/MainActivity.kt
+++ b/velocidi-sample/src/main/java/com/velocidi/sampleapp/MainActivity.kt
@@ -32,7 +32,11 @@ class MainActivity : AppCompatActivity() {
                 """.trimIndent()
 
             Velocidi.getInstance().track(
-                UserId("user_email_hash", "email_sha256"),
+                // test@example.org
+                UserId(
+                    "388c735eec8225c4ad7a507944dd0a975296baea383198aa87177f29af2c6f69",
+                    "email_sha256",
+                ),
                 eventJsonString,
             )
 
@@ -50,16 +54,24 @@ class MainActivity : AppCompatActivity() {
                 )
 
             Velocidi.getInstance().track(
-                UserId("user_email_hash", "email_sha256"),
+                // test@example.org
+                UserId(
+                    "388c735eec8225c4ad7a507944dd0a975296baea383198aa87177f29af2c6f69",
+                    "email_sha256",
+                ),
                 JSONObject(eventJsonObj),
             )
         }
 
         matchButton.setOnClickListener {
             Velocidi.getInstance().match(
-                "someProvider",
+                "web",
                 listOf(
-                    UserId("user_email_hash", "email_sha256"),
+                    // test@example.org
+                    UserId(
+                        "388c735eec8225c4ad7a507944dd0a975296baea383198aa87177f29af2c6f69",
+                        "email_sha256",
+                    ),
                     UserId("user_advertising_id", "gaid"),
                 ),
             )

--- a/velocidi-sdk/build.gradle
+++ b/velocidi-sdk/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     namespace "com.velocidi"
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 
@@ -58,8 +58,8 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.12.13'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.robolectric:robolectric:4.5.1'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.robolectric:robolectric:4.13'
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation 'org.assertj:assertj-core:3.12.2'
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.12.13'

--- a/velocidi-sdk/build.gradle
+++ b/velocidi-sdk/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 30
-
+    namespace "com.velocidi"
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 30
@@ -13,7 +13,9 @@ android {
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
-
+    buildFeatures {
+        buildConfig true
+    }
     buildTypes {
 
         debug {

--- a/velocidi-sdk/build.gradle
+++ b/velocidi-sdk/build.gradle
@@ -35,6 +35,14 @@ android {
 
     useLibrary 'org.apache.http.legacy'
 
+    compileOptions {
+         sourceCompatibility = JavaVersion.VERSION_11
+         targetCompatibility = JavaVersion.VERSION_11
+     }
+     kotlinOptions {
+         jvmTarget = "11"
+     }
+
     testOptions {
         unitTests {
             includeAndroidResources = true

--- a/velocidi-sdk/publish.gradle
+++ b/velocidi-sdk/publish.gradle
@@ -77,9 +77,9 @@ release {
     newVersionCommitMessage = "Set version to"
 
     git {
-        signTag = true
-        requireBranch = 'master'
-        pushToRemote = ''
+        signTag.set(true)
+        requireBranch.set('master')
+        pushToRemote.set('')
     }
 }
 

--- a/velocidi-sdk/src/main/AndroidManifest.xml
+++ b/velocidi-sdk/src/main/AndroidManifest.xml
@@ -1,1 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/velocidi-sdk/src/main/AndroidManifest.xml
+++ b/velocidi-sdk/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.velocidi"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/velocidi-sdk/src/main/kotlin/com/velocidi/Config.kt
+++ b/velocidi-sdk/src/main/kotlin/com/velocidi/Config.kt
@@ -8,17 +8,23 @@ import android.net.Uri
  * @property track Channel configuration for the track functionality
  * @property match Channel configuration for the match functionality
  */
-class Config(val track: Channel, val match: Channel) {
-
+class Config(
+    val track: Channel,
+    val match: Channel,
+) {
     constructor(url: Uri) : this(
         Channel(parseUrl(url, "tr", "events"), true),
-        Channel(parseUrl(url, "match", "match"), true)
+        Channel(parseUrl(url, "match", "match"), true),
     )
 
     internal companion object {
-
-        private fun parseUrl(url: Uri, prefix: String, endpoint: String): Uri =
-            Uri.Builder()
+        private fun parseUrl(
+            url: Uri,
+            prefix: String,
+            endpoint: String,
+        ): Uri =
+            Uri
+                .Builder()
                 .scheme(url.scheme)
                 .encodedAuthority("$prefix.${url.host}")
                 .appendEncodedPath(endpoint)
@@ -32,4 +38,7 @@ class Config(val track: Channel, val match: Channel) {
  * @property host endpoint URL
  * @property enabled
  */
-data class Channel(val host: Uri, val enabled: Boolean)
+data class Channel(
+    val host: Uri,
+    val enabled: Boolean,
+)

--- a/velocidi-sdk/src/main/kotlin/com/velocidi/HttpClient.kt
+++ b/velocidi-sdk/src/main/kotlin/com/velocidi/HttpClient.kt
@@ -3,11 +3,11 @@ package com.velocidi
 import android.net.Uri
 import android.util.Log
 import com.velocidi.Util.appendToUrl
-import java.io.IOException
-import java.lang.Exception
 import okhttp3.*
 import okhttp3.Request
 import org.json.JSONObject
+import java.io.IOException
+import java.lang.Exception
 
 /**
  * Http Client based on Android Volley
@@ -15,7 +15,8 @@ import org.json.JSONObject
  */
 internal class HttpClient {
     private val client =
-        OkHttpClient.Builder()
+        OkHttpClient
+            .Builder()
             .followRedirects(true)
             .followSslRedirects(true)
             .build()
@@ -36,15 +37,19 @@ internal class HttpClient {
         payload: JSONObject? = null,
         parameters: Map<String, String> = emptyMap(),
         headers: Map<String, String> = emptyMap(),
-        listener: ResponseListener = defaultListener
+        listener: ResponseListener = defaultListener,
     ) {
         val urlWithParams = url.appendToUrl(parameters)
-        val body = if (verb == Verb.POST) {
-            RequestBody.create(JSON_MEDIA_TYPE, payload?.toString() ?: "")
-        } else null
+        val body =
+            if (verb == Verb.POST) {
+                RequestBody.create(JSON_MEDIA_TYPE, payload?.toString() ?: "")
+            } else {
+                null
+            }
 
         val req =
-            Request.Builder()
+            Request
+                .Builder()
                 .headers(Headers.of(headers.toMutableMap()))
                 .url(urlWithParams.toString())
                 .method(verb.name, body)
@@ -52,36 +57,42 @@ internal class HttpClient {
 
         client.newCall(req).enqueue(
             object : Callback {
-                override fun onFailure(call: Call, e: IOException) {
+                override fun onFailure(
+                    call: Call,
+                    e: IOException,
+                ) {
                     listener.onError(e)
                 }
 
-                override fun onResponse(call: Call, response: Response) {
+                override fun onResponse(
+                    call: Call,
+                    response: Response,
+                ) {
                     if (!response.isSuccessful) {
                         listener.onError(Exception("Unexpected code $response"))
                     } else {
                         listener.onResponse("Success: ${response.message()}")
                     }
                 }
-            }
+            },
         )
     }
 
     enum class Verb { GET, POST }
 
     companion object {
-
         private val JSON_MEDIA_TYPE = MediaType.get("application/json; charset=utf-8")
 
-        val defaultListener = object : ResponseListener {
-            override fun onResponse(response: String) {
-                Log.v(Constants.LOG_TAG, response)
-            }
+        val defaultListener =
+            object : ResponseListener {
+                override fun onResponse(response: String) {
+                    Log.v(Constants.LOG_TAG, response)
+                }
 
-            override fun onError(ex: Exception) {
-                Log.v(Constants.LOG_TAG, ex.toString())
+                override fun onError(ex: Exception) {
+                    Log.v(Constants.LOG_TAG, ex.toString())
+                }
             }
-        }
     }
 }
 

--- a/velocidi-sdk/src/main/kotlin/com/velocidi/UserId.kt
+++ b/velocidi-sdk/src/main/kotlin/com/velocidi/UserId.kt
@@ -8,7 +8,10 @@ package com.velocidi
  * @see <a href="https://docs.velocidi.com/collect/user-ids">https://docs.velocidi.com/collect/user-ids</a>
  * @throws IllegalArgumentException Throws when id or type is empty
  */
-data class UserId(val id: String, val type: String = "gaid") {
+data class UserId(
+    val id: String,
+    val type: String = "gaid",
+) {
     init {
         require(id.isNotEmpty()) { "id cannot be empty" }
         require(type.isNotEmpty()) { "type cannot be empty" }

--- a/velocidi-sdk/src/main/kotlin/com/velocidi/Util.kt
+++ b/velocidi-sdk/src/main/kotlin/com/velocidi/Util.kt
@@ -37,7 +37,7 @@ internal object Util {
             val applicationInfo = packageManager.getApplicationInfo(packageName, 0)
             val packageInfo = packageManager.getPackageInfo(packageName, 0)
 
-            val appName = packageManager.getApplicationLabel(applicationInfo) ?: packageName
+            val appName = packageManager.getApplicationLabel(applicationInfo)
             val appVersion =
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                     packageInfo.longVersionCode.toString()

--- a/velocidi-sdk/src/main/kotlin/com/velocidi/Util.kt
+++ b/velocidi-sdk/src/main/kotlin/com/velocidi/Util.kt
@@ -11,7 +11,7 @@ internal data class ApplicationInfo(
     val appName: String,
     val appVersion: String,
     val androidSDK: String,
-    val device: String
+    val device: String,
 )
 
 internal object Util {
@@ -23,11 +23,12 @@ internal object Util {
      */
     fun getApplicationInfo(context: Context): ApplicationInfo {
         val sdkVersion = Build.VERSION.SDK_INT.toString()
-        val device = if (Build.MANUFACTURER != null && Build.MODEL != null) {
-            Build.MANUFACTURER + " " + Build.MODEL
-        } else {
-            Build.DEVICE ?: ""
-        }
+        val device =
+            if (Build.MANUFACTURER != null && Build.MODEL != null) {
+                Build.MANUFACTURER + " " + Build.MODEL
+            } else {
+                Build.DEVICE ?: ""
+            }
 
         return try {
             val packageManager = context.packageManager
@@ -37,11 +38,12 @@ internal object Util {
             val packageInfo = packageManager.getPackageInfo(packageName, 0)
 
             val appName = packageManager.getApplicationLabel(applicationInfo) ?: packageName
-            val appVersion = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                packageInfo.longVersionCode.toString()
-            } else {
-                packageInfo.versionName
-            }
+            val appVersion =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    packageInfo.longVersionCode.toString()
+                } else {
+                    packageInfo.versionName
+                }
 
             ApplicationInfo(appName.toString(), appVersion.toString(), sdkVersion, device)
         } catch (e: PackageManager.NameNotFoundException) {
@@ -63,7 +65,10 @@ internal object Util {
      * @param permission Permission string
      * @return true - has permission; otherwise - false
      */
-    fun checkPermission(context: Context, permission: String): Boolean {
+    fun checkPermission(
+        context: Context,
+        permission: String,
+    ): Boolean {
         val res = context.checkCallingOrSelfPermission(permission)
         return res == PackageManager.PERMISSION_GRANTED
     }
@@ -85,7 +90,11 @@ internal object Util {
     }
 
     fun JSONObject.toQueryParams(): Map<String, String> {
-        fun toQueryParamsAux(elem: Any?, qs: MutableMap<String, String>, path: String) {
+        fun toQueryParamsAux(
+            elem: Any?,
+            qs: MutableMap<String, String>,
+            path: String,
+        ) {
             when (elem) {
                 is JSONObject ->
                     for (key in elem.keys()) {

--- a/velocidi-sdk/src/main/kotlin/com/velocidi/Velocidi.kt
+++ b/velocidi-sdk/src/main/kotlin/com/velocidi/Velocidi.kt
@@ -19,8 +19,10 @@ import org.json.JSONObject
  *
  * @param context Android application context
  */
-open class Velocidi internal constructor(val config: Config, context: Context) {
-
+open class Velocidi internal constructor(
+    val config: Config,
+    context: Context,
+) {
     private val client = HttpClient()
 
     private val appInfo = Util.getApplicationInfo(context)
@@ -34,7 +36,7 @@ open class Velocidi internal constructor(val config: Config, context: Context) {
     private fun handleTask(req: Request) {
         val headers =
             mapOf(
-                "User-Agent" to Util.buildUserAgent(appInfo)
+                "User-Agent" to Util.buildUserAgent(appInfo),
             )
 
         val commonParams = mapOf("cookies" to "false")
@@ -47,9 +49,11 @@ open class Velocidi internal constructor(val config: Config, context: Context) {
                         HttpClient.Verb.GET,
                         config.track.host,
                         parameters = entity,
-                        headers = headers
+                        headers = headers,
                     )
-                } else return
+                } else {
+                    return
+                }
             is Request.MatchRequest ->
                 if (config.match.enabled) {
                     val entity = commonParams + req.toQueryParams()
@@ -58,9 +62,11 @@ open class Velocidi internal constructor(val config: Config, context: Context) {
                         HttpClient.Verb.GET,
                         config.match.host,
                         parameters = entity,
-                        headers = headers
+                        headers = headers,
                     )
-                } else return
+                } else {
+                    return
+                }
         }
     }
 
@@ -74,7 +80,10 @@ open class Velocidi internal constructor(val config: Config, context: Context) {
      * @param event Json String with the event performed by the user
      * @throws JSONException if the parsing the event fails
      */
-    fun track(userId: UserId, event: String) {
+    fun track(
+        userId: UserId,
+        event: String,
+    ) {
         val obj = JSONObject(event)
 
         val request = Request.TrackRequest(userId, obj)
@@ -90,7 +99,10 @@ open class Velocidi internal constructor(val config: Config, context: Context) {
      * @param userId User identifier
      * @param event JSONObject with the event performed by the user
      */
-    fun track(userId: UserId, event: JSONObject) {
+    fun track(
+        userId: UserId,
+        event: JSONObject,
+    ) {
         val request = Request.TrackRequest(userId, event)
         handleTask(request)
     }
@@ -104,7 +116,10 @@ open class Velocidi internal constructor(val config: Config, context: Context) {
      * @param userIds List of user ids to be linked
      * @throws IllegalArgumentException Throws when providerId is empty or userIds size is smaller than 2
      */
-    fun match(providerId: String, userIds: List<UserId>) {
+    fun match(
+        providerId: String,
+        userIds: List<UserId>,
+    ) {
         require(providerId.isNotEmpty()) { "providerId cannot be empty" }
         require(userIds.size >= 2) { "must provide at least 2 userIds" }
 
@@ -128,7 +143,10 @@ open class Velocidi internal constructor(val config: Config, context: Context) {
          * @return Velocidi instance
          */
         @JvmStatic
-        fun init(config: Config, context: Context): Velocidi {
+        fun init(
+            config: Config,
+            context: Context,
+        ): Velocidi {
             if (!Util.checkPermission(context, Manifest.permission.INTERNET)) {
                 throw SecurityException("Velocidi SDK requires Internet permission")
             }
@@ -151,7 +169,7 @@ open class Velocidi internal constructor(val config: Config, context: Context) {
                 true -> instance
                 false -> throw IllegalStateException(
                     """Velocidi SDK is not initialized
-                            Make sure to call Velocidi.init first."""
+                            Make sure to call Velocidi.init first.""",
                 )
             }
     }
@@ -159,8 +177,15 @@ open class Velocidi internal constructor(val config: Config, context: Context) {
 
 // ADT with the supported requests
 internal sealed class Request {
-    data class TrackRequest(val userId: UserId, val event: JSONObject) : Request()
-    data class MatchRequest(val providerId: String, val userIds: List<UserId>) : Request() {
+    data class TrackRequest(
+        val userId: UserId,
+        val event: JSONObject,
+    ) : Request()
+
+    data class MatchRequest(
+        val providerId: String,
+        val userIds: List<UserId>,
+    ) : Request() {
         fun toQueryParams(): Map<String, String> {
             val userIdsMap = userIds.map { it.toPair() }.toMap()
             return userIdsMap + Pair("providerId", providerId)

--- a/velocidi-sdk/src/test/AndroidManifest.xml
+++ b/velocidi-sdk/src/test/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- https://stackoverflow.com/a/70788673 -->
+    <application>
+            <activity
+                android:name="androidx.test.core.app.InstrumentationActivityInvoker$BootstrapActivity"
+                android:exported="true"
+                android:theme="@android:style/Theme" >
+                <intent-filter>
+                    <action android:name="android.intent.action.MAIN" />
+                </intent-filter>
+            </activity>
+            <activity
+                android:name="androidx.test.core.app.InstrumentationActivityInvoker$EmptyActivity"
+                android:exported="true"
+                android:theme="@android:style/Theme" >
+                <intent-filter>
+                    <action android:name="android.intent.action.MAIN" />
+                </intent-filter>
+            </activity>
+            <activity
+                android:name="androidx.test.core.app.InstrumentationActivityInvoker$EmptyFloatingActivity"
+                android:exported="true"
+                android:theme="@android:style/Theme.Dialog" >
+                <intent-filter>
+                    <action android:name="android.intent.action.MAIN" />
+                </intent-filter>
+            </activity>
+    </application>
+
+</manifest>

--- a/velocidi-sdk/src/test/kotlin/com/velocidi/HttpClientTest.kt
+++ b/velocidi-sdk/src/test/kotlin/com/velocidi/HttpClientTest.kt
@@ -16,7 +16,6 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class HttpClientTest {
-
     var server = MockWebServer()
     private val url = Uri.parse(server.url("/").toString())
     private var client = HttpClient()
@@ -47,7 +46,7 @@ class HttpClientTest {
         client.sendRequest(
             HttpClient.Verb.GET,
             url,
-            headers = mapOf("User-Agent" to "CustomUA")
+            headers = mapOf("User-Agent" to "CustomUA"),
         )
 
         val response = server.takeRequest()
@@ -74,10 +73,11 @@ class HttpClientTest {
         client.sendRequest(
             HttpClient.Verb.POST,
             url,
-            parameters = mapOf(
-                "x" to "foo",
-                "y" to "bar"
-            )
+            parameters =
+                mapOf(
+                    "x" to "foo",
+                    "y" to "bar",
+                ),
         )
 
         val response = server.takeRequest()

--- a/velocidi-sdk/src/test/kotlin/com/velocidi/TrackingEventsSerializationTest.kt
+++ b/velocidi-sdk/src/test/kotlin/com/velocidi/TrackingEventsSerializationTest.kt
@@ -10,334 +10,352 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class TrackingEventsSerializationTest {
-    private val defaultProduct = mapOf(
-        "[itemGroupId]" to "p125",
-        "[name]" to "My product",
-        "[brand]" to "Nike",
-        "[productType]" to "Shirts",
-        "[currency]" to "EUR",
-        "[promotions][0]" to "WINTERSALE",
-        "[adult]" to "false",
-        "[size]" to "S",
-        "[sizeSystem]" to "EU",
-        "[customFields][color]" to "blue",
-        "[id]" to "p125zc",
-        "[price]" to "102.5",
-        "[gender]" to "male"
-    )
+    private val defaultProduct =
+        mapOf(
+            "[itemGroupId]" to "p125",
+            "[name]" to "My product",
+            "[brand]" to "Nike",
+            "[productType]" to "Shirts",
+            "[currency]" to "EUR",
+            "[promotions][0]" to "WINTERSALE",
+            "[adult]" to "false",
+            "[size]" to "S",
+            "[sizeSystem]" to "EU",
+            "[customFields][color]" to "blue",
+            "[id]" to "p125zc",
+            "[price]" to "102.5",
+            "[gender]" to "male",
+        )
 
-    private val defaultProductObj = JSONObject(
-        """
-    {
-      "itemGroupId": "p125",
-      "name": "My product",
-      "brand": "Nike",
-      "productType": "Shirts",
-      "currency": "EUR",
-      "promotions": [
-        "WINTERSALE"
-      ],
-      "adult": false,
-      "size": "S",
-      "sizeSystem": "EU",
-      "customFields": {
-        "color": "blue"
-      },
-      "id": "p125zc",
-      "price": 102.5,
-      "gender": "male"
-    }
-        """.trimIndent()
-    )
+    private val defaultProductObj =
+        JSONObject(
+            """
+            {
+              "itemGroupId": "p125",
+              "name": "My product",
+              "brand": "Nike",
+              "productType": "Shirts",
+              "currency": "EUR",
+              "promotions": [
+                "WINTERSALE"
+              ],
+              "adult": false,
+              "size": "S",
+              "sizeSystem": "EU",
+              "customFields": {
+                "color": "blue"
+              },
+              "id": "p125zc",
+              "price": 102.5,
+              "gender": "male"
+            }
+            """.trimIndent(),
+        )
 
-    private val defaultLineItem = mapOf(
-        "[itemGroupId]" to "p125",
-        "[name]" to "My product",
-        "[brand]" to "Nike",
-        "[productType]" to "Shirts",
-        "[currency]" to "EUR",
-        "[promotions][0]" to "WINTERSALE",
-        "[adult]" to "false",
-        "[size]" to "S",
-        "[sizeSystem]" to "EU",
-        "[customFields][color]" to "blue",
-        "[lineItemId]" to "li125zc",
-        "[productId]" to "p125zc",
-        "[total]" to "102.5",
-        "[subtotal]" to "85",
-        "[tax]" to "11.5",
-        "[shipping]" to "6",
-        "[sku]" to "p125zc-5",
-        "[discount][value]" to "5",
-        "[discount][currency]" to "EUR",
-        "[refund]" to "0",
-        "[quantity]" to "1",
-        "[subscriptionDuration]" to "180",
+    private val defaultLineItem =
+        mapOf(
+            "[itemGroupId]" to "p125",
+            "[name]" to "My product",
+            "[brand]" to "Nike",
+            "[productType]" to "Shirts",
+            "[currency]" to "EUR",
+            "[promotions][0]" to "WINTERSALE",
+            "[adult]" to "false",
+            "[size]" to "S",
+            "[sizeSystem]" to "EU",
+            "[customFields][color]" to "blue",
+            "[lineItemId]" to "li125zc",
+            "[productId]" to "p125zc",
+            "[total]" to "102.5",
+            "[subtotal]" to "85",
+            "[tax]" to "11.5",
+            "[shipping]" to "6",
+            "[sku]" to "p125zc-5",
+            "[discount][value]" to "5",
+            "[discount][currency]" to "EUR",
+            "[refund]" to "0",
+            "[quantity]" to "1",
+            "[subscriptionDuration]" to "180",
+        )
 
-    )
+    private val defaultLineItemObj =
+        JSONObject(
+            """
+            {
+              "itemGroupId": "p125",
+              "name": "My product",
+              "brand": "Nike",
+              "productType": "Shirts",
+              "currency": "EUR",
+              "promotions": [
+                "WINTERSALE"
+              ],
+              "adult": false,
+              "size": "S",
+              "sizeSystem": "EU",
+              "customFields": {
+                "color": "blue"
+              },
+              "lineItemId": "li125zc",
+              "productId": "p125zc",
+              "total": 102.5,
+              "subtotal": 85,
+              "tax": 11.5,
+              "shipping": 6,
+              "sku": "p125zc-5",
+              "discount": {
+                "value": 5,
+                "currency": "EUR"
+              },
+              "refund": 0,
+              "quantity": 1,
+              "subscriptionDuration": 180
+            }
+            """.trimIndent(),
+        )
 
-    private val defaultLineItemObj = JSONObject(
-        """
-    {
-      "itemGroupId": "p125",
-      "name": "My product",
-      "brand": "Nike",
-      "productType": "Shirts",
-      "currency": "EUR",
-      "promotions": [
-        "WINTERSALE"
-      ],
-      "adult": false,
-      "size": "S",
-      "sizeSystem": "EU",
-      "customFields": {
-        "color": "blue"
-      },
-      "lineItemId": "li125zc",
-      "productId": "p125zc",
-      "total": 102.5,
-      "subtotal": 85,
-      "tax": 11.5,
-      "shipping": 6,
-      "sku": "p125zc-5",
-      "discount": {
-        "value": 5,
-        "currency": "EUR"
-      },
-      "refund": 0,
-      "quantity": 1,
-      "subscriptionDuration": 180
-    }
-        """.trimIndent()
-    )
+    private val defaultOrder =
+        mapOf(
+            "order[id]" to "or123",
+            "order[currency]" to "EUR",
+            "order[total]" to "102.5",
+            "order[subtotal]" to "85",
+            "order[tax]" to "11.5",
+            "order[shipping]" to "6",
+            "order[discount][value]" to "5",
+            "order[discount][currency]" to "EUR",
+            "order[refund]" to "0",
+            "order[paymentMethod]" to "Visa",
+            "order[shippingMethod]" to "UPS",
+            "order[shippingCountry]" to "France",
+            "order[promotions][0]" to "WINTERSALE",
+        )
 
-    private val defaultOrder = mapOf(
-        "order[id]" to "or123",
-        "order[currency]" to "EUR",
-        "order[total]" to "102.5",
-        "order[subtotal]" to "85",
-        "order[tax]" to "11.5",
-        "order[shipping]" to "6",
-        "order[discount][value]" to "5",
-        "order[discount][currency]" to "EUR",
-        "order[refund]" to "0",
-        "order[paymentMethod]" to "Visa",
-        "order[shippingMethod]" to "UPS",
-        "order[shippingCountry]" to "France",
-        "order[promotions][0]" to "WINTERSALE"
-    )
-
-    private val defaultOrderObj = JSONObject(
-        """
-      {
-        "id": "or123",
-        "currency": "EUR",
-        "total": 102.5,
-        "subtotal": 85,
-        "tax": 11.5,
-        "shipping": 6,
-        "discount": {
-          "value": 5,
-          "currency": "EUR"
-        },
-        "refund": 0,
-        "paymentMethod": "Visa",
-        "shippingMethod": "UPS",
-        "shippingCountry": "France",
-        "promotions": [
-          "WINTERSALE"
-        ]
-      }
-        """.trimIndent()
-    )
+    private val defaultOrderObj =
+        JSONObject(
+            """
+            {
+              "id": "or123",
+              "currency": "EUR",
+              "total": 102.5,
+              "subtotal": 85,
+              "tax": 11.5,
+              "shipping": 6,
+              "discount": {
+                "value": 5,
+                "currency": "EUR"
+              },
+              "refund": 0,
+              "paymentMethod": "Visa",
+              "shippingMethod": "UPS",
+              "shippingCountry": "France",
+              "promotions": [
+                "WINTERSALE"
+              ]
+            }
+            """.trimIndent(),
+        )
 
     @Test
     fun pageViewEventSerialization() {
-        val event = mapOf(
-            "clientId" to "velocidi",
-            "siteId" to "velocidi.com",
-            "type" to "pageView",
-            "customFields[debug]" to "true",
-            "customFields[role]" to "superuser",
-            "title" to "Welcome to your Shop",
-            "pageType" to "homepage",
-            "category" to "Shopping"
-        )
+        val event =
+            mapOf(
+                "clientId" to "velocidi",
+                "siteId" to "velocidi.com",
+                "type" to "pageView",
+                "customFields[debug]" to "true",
+                "customFields[role]" to "superuser",
+                "title" to "Welcome to your Shop",
+                "pageType" to "homepage",
+                "category" to "Shopping",
+            )
 
-        val eventObj = JSONObject(
-            """
-            {
-              "clientId": "velocidi",
-              "siteId": "velocidi.com",
-              "type": "pageView",
-              "customFields": {
-                "debug": "true",
-                "role": "superuser"
-              },
-              "title": "Welcome to your Shop",
-              "pageType": "homepage",
-              "category": "Shopping"
-            }
-            """.trimIndent()
-        )
+        val eventObj =
+            JSONObject(
+                """
+                {
+                  "clientId": "velocidi",
+                  "siteId": "velocidi.com",
+                  "type": "pageView",
+                  "customFields": {
+                    "debug": "true",
+                    "role": "superuser"
+                  },
+                  "title": "Welcome to your Shop",
+                  "pageType": "homepage",
+                  "category": "Shopping"
+                }
+                """.trimIndent(),
+            )
 
         containsExactlyInAnyOrder(event, eventObj.toQueryParams())
     }
 
     @Test
     fun appViewEventSerialization() {
-        val event = mapOf(
-            "clientId" to "velocidi",
-            "siteId" to "velocidi.com",
-            "type" to "appView",
-            "customFields[debug]" to "true",
-            "customFields[role]" to "superuser",
-            "title" to "Welcome Screen",
-        )
+        val event =
+            mapOf(
+                "clientId" to "velocidi",
+                "siteId" to "velocidi.com",
+                "type" to "appView",
+                "customFields[debug]" to "true",
+                "customFields[role]" to "superuser",
+                "title" to "Welcome Screen",
+            )
 
-        val eventObj = JSONObject(
-            """
-            {
-              "clientId": "velocidi",
-              "siteId": "velocidi.com",
-              "type": "appView",
-              "customFields": {
-                "debug": "true",
-                "role": "superuser"
-              },
-              "title": "Welcome Screen"
-            }
-            """.trimIndent()
-
-        )
+        val eventObj =
+            JSONObject(
+                """
+                {
+                  "clientId": "velocidi",
+                  "siteId": "velocidi.com",
+                  "type": "appView",
+                  "customFields": {
+                    "debug": "true",
+                    "role": "superuser"
+                  },
+                  "title": "Welcome Screen"
+                }
+                """.trimIndent(),
+            )
 
         containsExactlyInAnyOrder(event, eventObj.toQueryParams())
     }
 
     @Test
     fun productImpressionEventSerialization() {
-        val event = mutableMapOf(
-            "clientId" to "velocidi",
-            "siteId" to "velocidi.com",
-            "type" to "productImpression",
-            "customFields[debug]" to "true",
-            "customFields[role]" to "superuser",
-        )
+        val event =
+            mutableMapOf(
+                "clientId" to "velocidi",
+                "siteId" to "velocidi.com",
+                "type" to "productImpression",
+                "customFields[debug]" to "true",
+                "customFields[role]" to "superuser",
+            )
         event.putAll(defaultProduct.mapKeys { (k, _) -> "products[0]$k" })
 
-        val eventObj = JSONObject(
-            """
-            {
-              "clientId": "velocidi",
-              "siteId": "velocidi.com",
-              "type": "productImpression",
-              "customFields": {
-                "debug": "true",
-                "role": "superuser"
-              },
-              "products": [
-                $defaultProductObj
-              ]
-            }
-            """.trimIndent()
-        )
+        val eventObj =
+            JSONObject(
+                """
+                {
+                  "clientId": "velocidi",
+                  "siteId": "velocidi.com",
+                  "type": "productImpression",
+                  "customFields": {
+                    "debug": "true",
+                    "role": "superuser"
+                  },
+                  "products": [
+                    $defaultProductObj
+                  ]
+                }
+                """.trimIndent(),
+            )
 
         containsExactlyInAnyOrder(event, eventObj.toQueryParams())
     }
 
     @Test
     fun addToCartEventSerialization() {
-        val event = mutableMapOf(
-            "clientId" to "velocidi",
-            "siteId" to "velocidi.com",
-            "type" to "addToCart",
-            "customFields[debug]" to "true",
-            "customFields[role]" to "superuser",
-        )
+        val event =
+            mutableMapOf(
+                "clientId" to "velocidi",
+                "siteId" to "velocidi.com",
+                "type" to "addToCart",
+                "customFields[debug]" to "true",
+                "customFields[role]" to "superuser",
+            )
         event.putAll(defaultProduct.mapKeys { (k, _) -> "products[0]$k" })
 
-        val eventObj = JSONObject(
-            """
-            {
-              "clientId": "velocidi",
-              "siteId": "velocidi.com",
-              "type": "addToCart",
-              "customFields": {
-                "debug": "true",
-                "role": "superuser"
-              },
-              "products": [
-                $defaultProductObj
-              ]
-            }
-            """.trimIndent()
-        )
+        val eventObj =
+            JSONObject(
+                """
+                {
+                  "clientId": "velocidi",
+                  "siteId": "velocidi.com",
+                  "type": "addToCart",
+                  "customFields": {
+                    "debug": "true",
+                    "role": "superuser"
+                  },
+                  "products": [
+                    $defaultProductObj
+                  ]
+                }
+                """.trimIndent(),
+            )
 
         containsExactlyInAnyOrder(event, eventObj.toQueryParams())
     }
 
     @Test
     fun orderPlaceEventSerialization() {
-        val event = mutableMapOf(
-            "clientId" to "velocidi",
-            "siteId" to "velocidi.com",
-            "type" to "orderPlace",
-            "customFields[debug]" to "true",
-            "customFields[role]" to "superuser",
-        )
+        val event =
+            mutableMapOf(
+                "clientId" to "velocidi",
+                "siteId" to "velocidi.com",
+                "type" to "orderPlace",
+                "customFields[debug]" to "true",
+                "customFields[role]" to "superuser",
+            )
         event.putAll(defaultLineItem.mapKeys { (k, _) -> "lineItems[0]$k" })
         event.putAll(defaultOrder)
 
-        val eventObj = JSONObject(
-            """
-            {
-              "clientId": "velocidi",
-              "siteId": "velocidi.com",
-              "type": "orderPlace",
-              "customFields": {
-                "debug": "true",
-                "role": "superuser"
-              },
-              "lineItems": [
-                $defaultLineItemObj
-              ],
-              "order": $defaultOrderObj
-            }
-            """.trimIndent()
-        )
+        val eventObj =
+            JSONObject(
+                """
+                {
+                  "clientId": "velocidi",
+                  "siteId": "velocidi.com",
+                  "type": "orderPlace",
+                  "customFields": {
+                    "debug": "true",
+                    "role": "superuser"
+                  },
+                  "lineItems": [
+                    $defaultLineItemObj
+                  ],
+                  "order": $defaultOrderObj
+                }
+                """.trimIndent(),
+            )
 
         containsExactlyInAnyOrder(event, eventObj.toQueryParams())
     }
 
     @Test
     fun nullSerialization() {
-        val event = mapOf(
-            "clientId" to "velocidi",
-            "siteId" to "velocidi.com",
-            "type" to "pageView",
-            "title" to "Welcome to your Shop",
-            "pageType" to "homepage"
-        )
+        val event =
+            mapOf(
+                "clientId" to "velocidi",
+                "siteId" to "velocidi.com",
+                "type" to "pageView",
+                "title" to "Welcome to your Shop",
+                "pageType" to "homepage",
+            )
 
-        val eventObj = JSONObject(
-            """
-            {
-              "clientId": "velocidi",
-              "siteId": "velocidi.com",
-              "type": "pageView",
-              "title": "Welcome to your Shop",
-              "pageType": "homepage",
-              "category": null
-            }
-            """.trimIndent()
-        )
+        val eventObj =
+            JSONObject(
+                """
+                {
+                  "clientId": "velocidi",
+                  "siteId": "velocidi.com",
+                  "type": "pageView",
+                  "title": "Welcome to your Shop",
+                  "pageType": "homepage",
+                  "category": null
+                }
+                """.trimIndent(),
+            )
 
         containsExactlyInAnyOrder(event, eventObj.toQueryParams())
     }
 
     @Test
     fun nonPrimitiveTypeSerialization() {
-        data class Foo(val bar: String)
+        data class Foo(
+            val bar: String,
+        )
 
         val json = JSONObject()
         json.put("foo", Foo("bar"))

--- a/velocidi-sdk/src/test/kotlin/com/velocidi/VelocidiTest.kt
+++ b/velocidi-sdk/src/test/kotlin/com/velocidi/VelocidiTest.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
 import com.velocidi.util.containsRequestLine
-import java.util.concurrent.TimeUnit
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.assertj.core.api.Assertions.assertThat
@@ -15,10 +14,10 @@ import org.junit.Test
 import org.junit.rules.Timeout
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 class VelocidiTest {
-
     var server = MockWebServer()
 
     @Rule
@@ -42,29 +41,31 @@ class VelocidiTest {
 
         val context: Context = ApplicationProvider.getApplicationContext()
 
-        val appView = """
-        {
-          "clientId": "velocidi",
-          "siteId": "velocidi.com",
-          "type": "appView",
-          "customFields": {
-            "debug": "true",
-            "roles": ["superuser", "sudoer", "default"]
-          },
-          "title": "Welcome Screen"
-        }
-        """.trimIndent()
+        val appView =
+            """
+            {
+              "clientId": "velocidi",
+              "siteId": "velocidi.com",
+              "type": "appView",
+              "customFields": {
+                "debug": "true",
+                "roles": ["superuser", "sudoer", "default"]
+              },
+              "title": "Welcome Screen"
+            }
+            """.trimIndent()
 
-        val appViewQueryParams = mapOf(
-            "clientId" to "velocidi",
-            "siteId" to "velocidi.com",
-            "type" to "appView",
-            "customFields[debug]" to "true",
-            "customFields[roles][0]" to "superuser",
-            "customFields[roles][1]" to "sudoer",
-            "customFields[roles][2]" to "default",
-            "title" to "Welcome Screen",
-        ).asIterable().joinToString("&")
+        val appViewQueryParams =
+            mapOf(
+                "clientId" to "velocidi",
+                "siteId" to "velocidi.com",
+                "type" to "appView",
+                "customFields[debug]" to "true",
+                "customFields[roles][0]" to "superuser",
+                "customFields[roles][1]" to "sudoer",
+                "customFields[roles][2]" to "default",
+                "title" to "Welcome Screen",
+            ).asIterable().joinToString("&")
 
         Velocidi.instance = Velocidi(config, context)
 
@@ -74,7 +75,7 @@ class VelocidiTest {
 
         val response = server.takeRequest()
         response.containsRequestLine(
-            "GET /tr?cookies=false&$appViewQueryParams&id_gaid=123 HTTP/1.1"
+            "GET /tr?cookies=false&$appViewQueryParams&id_gaid=123 HTTP/1.1",
         )
     }
 
@@ -108,14 +109,14 @@ class VelocidiTest {
                 UserId("123"),
                 UserId(
                     "81df589b1dceacc2fa7c8f536015fcdf854eee721fdf282a91ed9c4b0c54dc76",
-                    "email_sha256"
-                )
-            )
+                    "email_sha256",
+                ),
+            ),
         )
 
         val response = server.takeRequest()
         response.containsRequestLine(
-            "GET /match?cookies=false&id_gaid=123&id_email_sha256=81df589b1dceacc2fa7c8f536015fcdf854eee721fdf282a91ed9c4b0c54dc76&providerId=provider1 HTTP/1.1"
+            "GET /match?cookies=false&id_gaid=123&id_email_sha256=81df589b1dceacc2fa7c8f536015fcdf854eee721fdf282a91ed9c4b0c54dc76&providerId=provider1 HTTP/1.1",
         )
     }
 
@@ -133,9 +134,9 @@ class VelocidiTest {
                 UserId("123"),
                 UserId(
                     "81df589b1dceacc2fa7c8f536015fcdf854eee721fdf282a91ed9c4b0c54dc76",
-                    "email_sha256"
-                )
-            )
+                    "email_sha256",
+                ),
+            ),
         )
 
         val response = server.takeRequest(2, TimeUnit.SECONDS)
@@ -159,9 +160,9 @@ class VelocidiTest {
                     UserId("123"),
                     UserId(
                         "81df589b1dceacc2fa7c8f536015fcdf854eee721fdf282a91ed9c4b0c54dc76",
-                        "email_sha256"
-                    )
-                )
+                        "email_sha256",
+                    ),
+                ),
             )
         }
 
@@ -173,8 +174,8 @@ class VelocidiTest {
             Velocidi.getInstance().match(
                 "provider1",
                 listOf(
-                    UserId("123")
-                )
+                    UserId("123"),
+                ),
             )
         }
 

--- a/velocidi-sdk/src/test/kotlin/com/velocidi/util/CustomAsserts.kt
+++ b/velocidi-sdk/src/test/kotlin/com/velocidi/util/CustomAsserts.kt
@@ -1,51 +1,56 @@
 package com.velocidi.util
 
-import java.net.URLDecoder
-import java.nio.charset.StandardCharsets
 import okhttp3.mockwebserver.RecordedRequest
 import org.assertj.core.api.Assertions
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 
-fun RecordedRequest.containsHeader(header: String, expectedHeader: String) {
+fun RecordedRequest.containsHeader(
+    header: String,
+    expectedHeader: String,
+) {
     val actualHeader = this.getHeader(header)
-    Assertions.assertThat(actualHeader)
+    Assertions
+        .assertThat(actualHeader)
         .isNotNull()
         .isNotEmpty()
         .overridingErrorMessage(
             "Expected header to be <%s> but got <%s>.",
             expectedHeader,
-            actualHeader
-        )
-        .isEqualTo(expectedHeader)
+            actualHeader,
+        ).isEqualTo(expectedHeader)
 }
 
 fun RecordedRequest.containsRequestLine(expectedReqLine: String) {
-    Assertions.assertThat(
-        URLDecoder.decode(this.requestLine, StandardCharsets.UTF_8.toString())
-    )
-        .isNotNull()
+    Assertions
+        .assertThat(
+            URLDecoder.decode(this.requestLine, StandardCharsets.UTF_8.toString()),
+        ).isNotNull()
         .isNotEmpty()
         .overridingErrorMessage(
             "Expected header to be <%s> but got <%s>.",
             expectedReqLine,
-            this.requestLine
-        )
-        .isEqualTo(expectedReqLine)
+            this.requestLine,
+        ).isEqualTo(expectedReqLine)
 }
 
 fun RecordedRequest.containsBody(expectedBody: String) {
     val body = String(this.body.readByteArray())
-    Assertions.assertThat(body)
+    Assertions
+        .assertThat(body)
         .isNotNull()
         .isNotEmpty()
         .overridingErrorMessage(
             "Expected body to be <%s> but got <%s>.",
             expectedBody,
-            body
-        )
-        .isEqualTo(expectedBody)
+            body,
+        ).isEqualTo(expectedBody)
 }
 
-fun <K, V> containsExactlyInAnyOrder(actual: Map<K, V>, other: Map<K, V>) {
+fun <K, V> containsExactlyInAnyOrder(
+    actual: Map<K, V>,
+    other: Map<K, V>,
+) {
     Assertions.assertThat(actual).containsAllEntriesOf(other)
     Assertions.assertThat(other).containsAllEntriesOf(actual)
 }


### PR DESCRIPTION
Updates Gradle to 8.9 along with the build plugins, to bring the project up to date.

As a side effect:
- There were multiple style changes in the code, due to the new version of ktlint.
- The target java version is now explicitly set to 11, this is aligned with https://github.com/adzerk/audience-android-sdk/pull/40
- The target android SDK version is now 33 (Android 13). This is aligned with https://developer.android.com/google/play/requirements/target-sdk
- Namespaces are now defined in the build definition, not in the manifest
- Activities need to be explicitly marked as exported (this had some extra implications on the unit test manifest)

This PR also updates the sample app to use a valid email hash (for `test@example.org`) and the default match provider. This way, to try out the sample app, one just needs to point it to the correct domains.